### PR TITLE
ci: 修复预览版文档构建失败的问题

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -37,7 +37,7 @@ jobs:
           pnpm bootstrap
       - name: 构建文档站点
         run: |
-          pnpm doc-gen:edge
+          pnpm doc-gen
           pnpm docs:build --base "/api-node-sdk/"
       - name: 设置环境
         uses: actions/configure-pages@v3

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "bootstrap": "sh scripts/bootstrap.sh",
     "build": "sh scripts/build.sh",
     "doc-gen": "ts-node scripts/doc-gen.ts",
-    "doc-gen:edge": "ts-node scripts/doc-gen.ts \/api-node-sdk\/",
     "docs-to-interface": "ts-node scripts/docs-to-interface.ts",
     "generate-api-docs": "ts-node scripts/generate-api-docs.ts",
     "docs:dev": "vitepress dev docs --port 8771",

--- a/scripts/doc-gen.ts
+++ b/scripts/doc-gen.ts
@@ -1,6 +1,5 @@
 import * as typedoc from 'typedoc';
 import * as path from 'path';
-import { argv } from 'process';
 
 const OUT_DIR = path.resolve(__dirname, '../docs/api');
 
@@ -14,7 +13,6 @@ const OUT_DIR = path.resolve(__dirname, '../docs/api');
     entryDocument: 'index.md',
     hideInPageTOC: true,
     hideBreadcrumbs: true,
-    publicPath: argv[2],
   });
   const project = app.convert();
   if (!project) throw new Error('生成失败');


### PR DESCRIPTION
修复 vite 构建预览版文档时报错 `dead links found`。