### PR TITLE
fix: 修复无法导入在 `src/typings/*.ts` 定义的的值的问题

### DIFF
--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -1,8 +1,8 @@
-export type * from './chat';
-export type * from './circle';
-export type * from './credit';
-export type * from './general';
-export type * from './message';
-export type * from './permission';
-export type * from './role';
-export type * from './user';
+export * from './chat';
+export * from './circle';
+export * from './credit';
+export * from './general';
+export * from './message';
+export * from './permission';
+export * from './role';
+export * from './user';


### PR DESCRIPTION
```ts
import { Permission } from 'fanbook-api-node-sdk'; // is an enum, as a value
```